### PR TITLE
Chore: add a .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+__pycache__


### PR DESCRIPTION
This PR takes care of some chores such as 

- Removing the `.idea` and `__pycache__`.


I've initiated this as a draft in order to add/update the docs later on once we've had some discussion over the things mentioned here https://github.com/stephane-robin/crisprbuilder_tb_new/issues/1