### PR TITLE
feat/dockerfile: dockerize the crisprbuilder_tb_new package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+#FROM  continuumio/miniconda3:4.8.2-alpine 
+
+FROM  continuumio/miniconda3:4.8.2 
+
+RUN conda create --name pymtc python=3.6 -y
+
+SHELL ["conda", "run", "-n", "pymtc", "/bin/bash", "-c"]
+
+RUN pip install crisprbuilder_tb
+
+RUN conda install -c bioconda parallel-fastq-dump blast -y
+
+RUN conda install -c kantorlab blastn -y
+
+ENTRYPOINT ["conda", "run", "-n", "pymtc", "python", "-m", "crisprbuilder_tb"]
+
+
+# Usage
+# Build the docker image like so
+# docker build -d crisprbuilder_tb ./Dockerfile
+# docker run crisprbuilder_tb --collect ERR2704808


### PR DESCRIPTION
@stephane-robin , here's a draft implementation of the `docker` container for `crisprbuilder_tb_new` package - this works cross-platform.


Build the docker image like so
```
docker build -d crisprbuilder_tb ./Dockerfile
```

Usage
```
docker run crisprbuilder_tb --collect ERR2704808
```

If you like the general direction, I'd finalize this soon.